### PR TITLE
Update \kastenarray with automatic width selection

### DIFF
--- a/IChO_Aufgabentemplate_old/2025-3-14.tex
+++ b/IChO_Aufgabentemplate_old/2025-3-14.tex
@@ -63,10 +63,11 @@
 
 
 % Der Befeil 
-% \kastenarray{Breite}{Hoehe}[Abstand][tight]{label1,label2,...}{Inhalt1,Inhalt2,...}
+% \kastenarray[Breite]{Hoehe}[Abstand][tight]{label1,label2,...}{Inhalt1,Inhalt2,...}
 % erstellt gelabelte Kaesten in einer Reihe und ist fuer die Abfrage von mehreren Strukturen gedacht.
 % Dieser akzeptiert 6 Argumente, wovon 2 optional sind.
-% Breite: Die Breite jedes Kastens
+% Breite: Optional. Die Breite jedes Kastens. Falls nicht angegeben, wird die Breite 
+%         automatisch berechnet, sodass die Kästen die gesamte Textbreite einnehmen.
 % Hoehe: Die Hoehe jedes Kastens
 % Abstand: Optional. Der Abstand zwischen den Kästen. Default ist 0cm.
 % tight: Optional. Wenn tight=t, dann wird der verticale Abstand nach den Kaesten auf entfernt. 
@@ -80,22 +81,26 @@
 
 % Kastenarray mit 2 Kästen, 6 cm breit, 4 cm hoch, Abstand 0 cm (default) und tight=f (default),
 % da danach noch ein Kastenarray folgt.
-\kastenarray{6cm}{4cm}{Q,W}{\includegraphics[width=5.5cm]{Komplex.eps},\includegraphics[width=5.5cm]{Ligand.eps}}
+\kastenarray[6cm]{4cm}{Q,W}{\includegraphics[width=5.5cm]{Komplex.eps},\includegraphics[width=5.5cm]{Ligand.eps}}
 
 % Kastenarray mit 4 Kästen, 2.5 cm breit, 3 cm hoch, Abstand 0.2 cm und tight=f,
 % da danach noch ein Kastenarray folgt.
-\kastenarray{2.5cm}{3cm}[0.2cm][t]{G,J,I,W}{1234,6425,672,6489}
+\kastenarray[2.5cm]{3cm}[0.2cm][t]{G,J,I,W}{1234,6425,672,6489}
 
 % Kastenarray mit 3 Kästen, 3 cm breit, 4 cm hoch, Abstand 0cm und tight leer gelassen,
 % da danach Text folgt.
-\kastenarray{3cm}{4cm}[0cm][]{C,D,S}{0123,4567,890a}
+\kastenarray[3cm]{4cm}[0cm][]{C,D,S}{0123,4567,890a}
 
-Hier ein Text. 
+% Kastenarray mit 3 Kästen, Breite automatisch bestimmt, 2 cm hoch, Abstand 0cm und 
+% tight leer gelassen, da danach Text folgt.
+\kastenarray{2cm}[0cm][]{C,D,S}{0123,4567,890a}
+
+Hier ein Text.
 
 % Noch zwei Kastenarrays.
-\kastenarray{7cm}{7cm}{1,2}{Molekuel1,Molekuel2}
+\kastenarray[7cm]{7cm}{1,2}{Molekuel1,Molekuel2}
 
-\kastenarray{7cm}{7cm}[0cm][]{3,4}{Molekuel3,Molekuel4}
+\kastenarray[7cm]{7cm}[0cm][]{3,4}{Molekuel3,Molekuel4}
 
 Hier ein Text.
 \newpage

--- a/IChO_Aufgabentemplate_old/ichobooklet.cls
+++ b/IChO_Aufgabentemplate_old/ichobooklet.cls
@@ -102,6 +102,7 @@
 \usepackage{chemscheme} %scheme analog figure
 \usepackage{chemformula}
 \usepackage{chemmacros}
+\let\listofschemes\relax
 \usepackage{chemgreek,upgreek}\selectchemgreekmapping{upgreek}
 \usepackage{chemfig}
 \newcommand{\actualscale}{1.0} % give here your wished scale

--- a/IChO_Aufgabentemplate_old/ichobooklet.cls
+++ b/IChO_Aufgabentemplate_old/ichobooklet.cls
@@ -751,6 +751,7 @@
 \tl_new:N \l_tmpl_tl
 \tl_new:N \l_tmpr_tl
 \tl_new:N \l_frame_tl
+\dim_new:N \l_box_width_dim  % Declare \l_box_width_dim as a dimension variable
 
 % public package interface command
 \cs_new:Npn \kastenarray_zip:nnnnn #1 #2 #3 #4 #5 {
@@ -809,14 +810,31 @@
 }
 
 % xparse interface
-\NewDocumentCommand{\kastenarray}{ m m O{0cm} O{t} m m }{
-  \kastenarray_zip:nnnnn {#1} {#2} {#3} {#5} {#6}
+\NewDocumentCommand{\kastenarray}{ O{} m O{0cm} O{t} m m }{
+  % Determine the box width based on the first argument
+  \tl_if_empty:nTF {#1} {
+    % Calculate width dynamically if not provided
+    \seq_set_split:Nnn \l_tmpa_seq {,} {#5}  % Split labels into sequence
+    \int_set:Nn \l_tmpb_int {\seq_count:N \l_tmpa_seq}  % Count number of labels (n)
+    \fp_set:Nn \l_box_width_fp {(\dim_to_fp:n {\linewidth} - (\l_tmpb_int - 1) * \dim_to_fp:n {#3}) / \l_tmpb_int}
+    \dim_set:Nn \l_box_width_dim {\fp_to_dim:N \l_box_width_fp}
+  } {
+    % Use the provided width if given, converting it to a floating-point number
+    \dim_set:Nn \l_box_width_dim {#1}
+  }
+
+  % Pass the computed width (or provided width) to the internal function
+  \kastenarray_zip:nnnnn {\l_box_width_dim} {#2} {#3} {#5} {#6}
+
+  % Conditionally add vspace if the fourth argument is "t"
   \IfValueTF{#4}{%
     \tl_if_eq:nnTF {#4} {t} {
       \vspace*{-2.16\baselineskip}
     }{}
   }{}
 }
+
+
 \ExplSyntaxOff
 
 % other commands


### PR DESCRIPTION
Update \kastenarray with automatic width selection, avoid multiple definition of \listofschemes.
Follow up of #6.